### PR TITLE
Readme, useAnyThenable option, and don't reject returned Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ maybePromise(asyncSum, 1, 'x').catch(err => console.error(err)); // TypeError
 
 The maybePromiseFactory accepts two arguments:
 
-* @param {class} `promiseConstructor` A Promise implementation (e.g. `Bluebird` or `Promise`)
-* @param {boolean} `[useAnyThenable]` If truthy, any Promise implementation is considered a promise; otherwise, only instances of the `promiseConstructor` are considered promises.
+* {class} `promiseConstructor` A Promise implementation (e.g. `Bluebird` or `Promise`)
+* {boolean} `[useAnyThenable]` If truthy, any Promise implementation is considered a promise; otherwise, only instances of the `promiseConstructor` are considered promises.
 
 The maybePromiseFactory returns a maybePromise function, which is passed a function (synchronous or asynchronous) and any parameters to invoke it with. It returns an instance of `promiseConstructor`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# maybe-promise-factory
+Calls a function and wraps the retval or exception in a Promise only if it didn't already return a Promise; like Twisted's maybeDeferred.  Turns a sync-or-Promise API into a Promise API.
+
+## Installation
+
+Install with `npm install maybe-promise-factory`.
+
+## Usage
+
+```js
+const maybePromise = require('maybe-promise-factory')(Promise);
+
+function syncSum (a, b) {
+  if (typeof a !== 'number' || typeof b !== 'number') {
+    throw new TypeError('Invaild arguments passed to syncSum');
+  }
+  return a + b;
+}
+
+function asyncSum (a, b) {
+  return new Promise((resolve, reject) => {
+    if (typeof a !== 'number' || typeof b !== 'number') {
+      reject(new TypeError('Invalid arguments passed to asyncSum'));
+      return;
+    }
+    resolve(a + b);
+  });
+}
+
+maybePromise(syncSum, 1, 2).then(res => console.log(res)); // 3
+maybePromise(syncSum, 1, 'x').catch(err => console.error(err)); // TypeError
+
+maybePromise(asyncSum, 1, 2).then(res => console.log(res)); // 3
+maybePromise(asyncSum, 1, 'x').catch(err => console.error(err)); // TypeError
+```
+
+## maybePromiseFactory
+
+The maybePromiseFactory accepts two arguments:
+
+* @param {class} `promiseConstructor` A Promise implementation (e.g. `Bluebird` or `Promise`)
+* @param {boolean} `[useAnyThenable]` If truthy, any Promise implementation is considered a promise; otherwise, only instances of the `promiseConstructor` are considered promises.
+
+The maybePromiseFactory returns a maybePromise function, which is passed a function (synchronous or asynchronous) and any parameters to invoke it with. It returns an instance of `promiseConstructor`.

--- a/index.js
+++ b/index.js
@@ -1,7 +1,16 @@
 "use strong";
 "use strict";
 
-module.exports = function maybePromiseFactory(promiseConstructor) {
+/**
+ * Constructs a maybePromise function.
+ * @param {class} promiseConstructor A Promise implementation (e.g. `Bluebird` or `Promise`)
+ * @param {boolean} [useAnyThenable] If truthy, any Promise implementation is considered a promise; otherwise,
+ * only instances of the `promiseConstructor` are considered promises.
+ * @returns {Function} A function that takes a function and arguments. Invokes the function with arguments. If
+ * the result of the function is a promise, it is returned. Otherwise, the result is converted to a promise.
+ * If an error is thrown, a rejected promise is returned.
+ */
+module.exports = function maybePromiseFactory(promiseConstructor, useAnyThenable) {
 	return function maybePromise(f, ...args) {
 		let result;
 		try {
@@ -10,10 +19,8 @@ module.exports = function maybePromiseFactory(promiseConstructor) {
 			return promiseConstructor.reject(e);
 		}
 
-		if(result instanceof promiseConstructor) {
+		if(result instanceof promiseConstructor || (useAnyThenable && result && typeof result.then === 'function')) {
 			return result;
-		} else if(result instanceof Error) {
-			return promiseConstructor.reject(result);
 		} else {
 			return promiseConstructor.resolve(result);
 		}


### PR DESCRIPTION
Hi!

I made some adjustments to suit what I needed for my project, so these may be opinionated, but I wanted to offer them anyway.

In this PR:
- A readme describing parameters, usage, and examples.
- A new option, `useAnyThenable`, that allows instances of other Promise libraries to still be treated as promises within the maybePromise function (e.g. `const maybePromise = require('maybe-promise-factory')(Promise); maybePromise(someAsyncFn);` where `someAsyncFn` returns a Bluebird promise).
- An opinionated logic change: I'd argue that a synchronous function returning an Error object is not equivalent to a synchronous function returning an Error (e.g. a function `getValidationError` should not throw or, equivalently, reject a promise -- it should return/resolve with an Error instance).
